### PR TITLE
Un-hide node/bus status section in the node tree view

### DIFF
--- a/src/lib/udtgui/canopen/busnodestreeview.cpp
+++ b/src/lib/udtgui/canopen/busnodestreeview.cpp
@@ -53,8 +53,6 @@ BusNodesTreeView::BusNodesTreeView(CanOpen *canOpen, QWidget *parent)
     setSortingEnabled(true);
     setSelectionBehavior(QAbstractItemView::SelectRows);
     sortByColumn(0, Qt::AscendingOrder);
-
-    header()->hideSection(BusNodesModel::Status);
 }
 
 BusNodesTreeView::~BusNodesTreeView()


### PR DESCRIPTION
Status can be hard to read with only the color bullet on the node icon, especially for people with color blindness.